### PR TITLE
Supported uninitialized memory allocation

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -46,7 +46,7 @@ jobs:
       env:
         CC: ${{matrix.config.cc}}
         CXX: ${{matrix.config.cxx}}
-      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DLEGACY_MODE=ON -DNO_DEBUGGER=${{matrix.no-debugger}}
+      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DNO_DEBUGGER=${{matrix.no-debugger}}
 
     - name: Build
       working-directory: ${{runner.workspace}}/build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,14 +30,6 @@ add_compile_definitions(APP_VERSION_MAJOR=${PROJECT_VERSION_MAJOR})
 add_compile_definitions(APP_VERSION_MINOR=${PROJECT_VERSION_MINOR})
 add_compile_definitions(APP_VERSION_PATCH=${PROJECT_VERSION_PATCH})
 
-# definitions about build option
-# legacy mode: don't complain about symbol redefinition
-option(LEGACY_MODE "enable legacy mode" OFF)
-if(LEGACY_MODE)
-  message("Legacy mode has been enabled.")
-  add_compile_definitions(VM_LEGACY_MODE)
-endif()
-
 # no debugger: disable the built-in debugger of MiniVM
 option(NO_DEBUGGER "disable the built-in debugger" OFF)
 if(NO_DEBUGGER)

--- a/src/mem/dense.cpp
+++ b/src/mem/dense.cpp
@@ -1,17 +1,19 @@
 #include "mem/dense.h"
 
 #include <cstdlib>
+#include <cstring>
 #include <cassert>
 
 void DenseMemoryPool::FreeMems() {
   std::free(mems_);
 }
 
-MemId DenseMemoryPool::Allocate(std::uint32_t size) {
+MemId DenseMemoryPool::Allocate(std::uint32_t size, bool init) {
   // allocate memory
   auto id = mem_size_;
   mem_size_ += size;
   mems_ = reinterpret_cast<std::uint8_t *>(std::realloc(mems_, mem_size_));
+  if (init) std::memset(mems_ + id, 0, size);
   return id;
 }
 

--- a/src/mem/dense.cpp
+++ b/src/mem/dense.cpp
@@ -1,24 +1,31 @@
 #include "mem/dense.h"
 
+#include <cstdlib>
 #include <cassert>
+
+void DenseMemoryPool::FreeMems() {
+  std::free(mems_);
+}
 
 MemId DenseMemoryPool::Allocate(std::uint32_t size) {
   // allocate memory
-  auto id = mems_.size();
-  mems_.resize(mems_.size() + size);
+  auto id = mem_size_;
+  mem_size_ += size;
+  mems_ = reinterpret_cast<std::uint8_t *>(std::realloc(mems_, mem_size_));
   return id;
 }
 
 void *DenseMemoryPool::GetAddress(MemId id) {
-  if (id >= mems_.size()) return nullptr;
-  return mems_.data() + id;
+  if (id >= mem_size_) return nullptr;
+  return mems_ + id;
 }
 
 void DenseMemoryPool::SaveState() {
-  states_.push(mems_.size());
+  states_.push(mem_size_);
 }
 
 void DenseMemoryPool::RestoreState() {
-  mems_.resize(states_.top());
+  auto last_size = states_.top();
   states_.pop();
+  mems_ = reinterpret_cast<std::uint8_t *>(std::realloc(mems_, last_size));
 }

--- a/src/mem/dense.h
+++ b/src/mem/dense.h
@@ -11,7 +11,8 @@
 // all memory will be allocated contiguously in one place
 class DenseMemoryPool : public MemoryPoolInterface {
  public:
-  DenseMemoryPool() {}
+  DenseMemoryPool() : mems_(nullptr), mem_size_(0) {}
+  ~DenseMemoryPool() { FreeMems(); }
 
   MemId Allocate(std::uint32_t size) override;
   void *GetAddress(MemId id) override;
@@ -19,8 +20,13 @@ class DenseMemoryPool : public MemoryPoolInterface {
   void RestoreState() override;
 
  private:
+  // free all allocated memories
+  void FreeMems();
+
   // all allocated memories
-  std::vector<std::uint8_t> mems_;
+  std::uint8_t *mems_;
+  // size of allocated memories
+  std::uint32_t mem_size_;
   // stack of saved states
   std::stack<std::uint32_t> states_;
 };

--- a/src/mem/dense.h
+++ b/src/mem/dense.h
@@ -14,7 +14,7 @@ class DenseMemoryPool : public MemoryPoolInterface {
   DenseMemoryPool() : mems_(nullptr), mem_size_(0) {}
   ~DenseMemoryPool() { FreeMems(); }
 
-  MemId Allocate(std::uint32_t size) override;
+  MemId Allocate(std::uint32_t size, bool init) override;
   void *GetAddress(MemId id) override;
   void SaveState() override;
   void RestoreState() override;

--- a/src/mem/pool.h
+++ b/src/mem/pool.h
@@ -14,7 +14,7 @@ class MemoryPoolInterface {
 
   // allocate a new memory with the specific size
   // returns memory id
-  virtual MemId Allocate(std::uint32_t size) = 0;
+  virtual MemId Allocate(std::uint32_t size, bool init) = 0;
   // get the memory base address of the specific memory id
   // returns 'nullptr' if failed
   virtual void *GetAddress(MemId id) = 0;

--- a/src/mem/sparse.cpp
+++ b/src/mem/sparse.cpp
@@ -1,11 +1,22 @@
 #include "mem/sparse.h"
 
 #include <cassert>
+#include <type_traits>
+
+namespace {
+
+// make a unique pointer of uninitialized array type
+template <typename T>
+std::unique_ptr<T> MakeUninit(std::uint32_t size) {
+  return std::unique_ptr<T>(new std::remove_extent_t<T>[size]);
+}
+
+}  // namespace
 
 MemId SparseMemoryPool::Allocate(std::uint32_t size) {
   // allocate memory
   auto id = mem_size_;
-  auto mem = std::make_unique<std::uint8_t[]>(size);
+  auto mem = MakeUninit<std::uint8_t[]>(size);
   auto ret = mems_.insert({id, std::move(mem)}).second;
   static_cast<void>(ret);
   assert(ret);

--- a/src/mem/sparse.cpp
+++ b/src/mem/sparse.cpp
@@ -1,7 +1,7 @@
 #include "mem/sparse.h"
 
-#include <cassert>
 #include <type_traits>
+#include <cassert>
 
 namespace {
 
@@ -13,10 +13,11 @@ std::unique_ptr<T> MakeUninit(std::uint32_t size) {
 
 }  // namespace
 
-MemId SparseMemoryPool::Allocate(std::uint32_t size) {
+MemId SparseMemoryPool::Allocate(std::uint32_t size, bool init) {
   // allocate memory
   auto id = mem_size_;
-  auto mem = MakeUninit<std::uint8_t[]>(size);
+  auto mem = init ? std::make_unique<std::uint8_t[]>(size)
+                  : MakeUninit<std::uint8_t[]>(size);
   auto ret = mems_.insert({id, std::move(mem)}).second;
   static_cast<void>(ret);
   assert(ret);

--- a/src/mem/sparse.h
+++ b/src/mem/sparse.h
@@ -15,7 +15,7 @@ class SparseMemoryPool : public MemoryPoolInterface {
  public:
   SparseMemoryPool() : mem_size_(0) {}
 
-  MemId Allocate(std::uint32_t size) override;
+  MemId Allocate(std::uint32_t size, bool init) override;
   void *GetAddress(MemId id) override;
   void SaveState() override;
   void RestoreState() override;

--- a/src/vm/vm.cpp
+++ b/src/vm/vm.cpp
@@ -179,9 +179,7 @@ std::optional<VMOpr> VM::Run() {
   // allocate memory for variable
   VM_LABEL(Var) {
     auto succ = envs_.top().first->insert({inst->opr, 0}).second;
-#ifndef VM_LEGACY_MODE
     VM_ASSERT(succ, kVMErrorSymbolRedef);
-#endif
     static_cast<void>(succ);
     VM_NEXT(1);
   }
@@ -190,9 +188,7 @@ std::optional<VMOpr> VM::Run() {
   VM_LABEL(Arr) {
     // add a new entry to environment
     auto ret = envs_.top().first->insert({inst->opr, 0});
-#ifndef VM_LEGACY_MODE
     VM_ASSERT(ret.second, kVMErrorSymbolRedef);
-#endif
     // allocate a new memory
     if (ret.second) ret.first->second = mem_pool_->Allocate(PopValue());
     VM_NEXT(1);

--- a/src/vm/vm.cpp
+++ b/src/vm/vm.cpp
@@ -158,7 +158,7 @@ void VM::Reset() {
   global_env_ = envs_.top().first;
   // save current state of memory pool
   mem_pool_->SaveState();
-  // clear all static registers
+  // reset all static registers
   regs_.assign(regs_.size(), 0xdeadc0de);
   // reset error code
   error_code_ = 0;

--- a/src/vm/vm.cpp
+++ b/src/vm/vm.cpp
@@ -159,7 +159,7 @@ void VM::Reset() {
   // save current state of memory pool
   mem_pool_->SaveState();
   // clear all static registers
-  regs_.assign(regs_.size(), 0);
+  regs_.assign(regs_.size(), 0xdeadc0de);
   // reset error code
   error_code_ = 0;
 }

--- a/src/vmconf.cpp
+++ b/src/vmconf.cpp
@@ -189,40 +189,59 @@ inline VMOpr &GetParam(VM &vm, std::size_t param_id) {
   return vm.regs(static_cast<RegId>(TokenReg::A0) + param_id);
 }
 
+void ResetCallerSaveRegs(VM &vm) {
+  for (RegId i = static_cast<RegId>(TokenReg::T0);
+       i < static_cast<RegId>(TokenReg::A7); ++i) {
+    vm.regs(i) = 0xdeadc0de;
+  }
+}
+
 bool GetInt(VM &vm) {
+  ResetCallerSaveRegs(vm);
   std::cin >> GetRetVal(vm);
   return true;
 }
 
 bool GetCh(VM &vm) {
+  ResetCallerSaveRegs(vm);
   GetRetVal(vm) = std::cin.get();
   return true;
 }
 
 bool GetArray(VM &vm) {
-  return impl::GetArray(vm, GetRetVal(vm), GetParam(vm, 0));
+  auto arr = GetParam(vm, 0);
+  ResetCallerSaveRegs(vm);
+  return impl::GetArray(vm, GetRetVal(vm), arr);
 }
 
 bool PutInt(VM &vm) {
   std::cout << GetParam(vm, 0);
+  ResetCallerSaveRegs(vm);
   return true;
 }
 
 bool PutCh(VM &vm) {
   std::cout.put(GetParam(vm, 0));
+  ResetCallerSaveRegs(vm);
   return true;
 }
 
 bool PutArray(VM &vm) {
-  return impl::PutArray(vm, GetParam(vm, 0), GetParam(vm, 1));
+  auto len = GetParam(vm, 0), arr = GetParam(vm, 1);
+  ResetCallerSaveRegs(vm);
+  return impl::PutArray(vm, len, arr);
 }
 
 bool StartTime(VM &vm) {
-  return impl::StartTime(GetParam(vm, 0));
+  auto line_num = GetParam(vm, 0);
+  ResetCallerSaveRegs(vm);
+  return impl::StartTime(line_num);
 }
 
 bool StopTime(VM &vm) {
-  return impl::StopTime(GetParam(vm, 0));
+  auto line_num = GetParam(vm, 0);
+  ResetCallerSaveRegs(vm);
+  return impl::StopTime(line_num);
 }
 
 }  // namespace tigger

--- a/src/vmconf.cpp
+++ b/src/vmconf.cpp
@@ -266,4 +266,5 @@ void InitTiggerVM(VM &vm) {
   // add library functions
   ADD_LIBS(vm);
   vm.Reset();
+  vm.regs(static_cast<RegId>(TokenReg::X0)) = 0;
 }


### PR DESCRIPTION
In this version, MiniVM will not perform initialization in the local allocation, but will still initialize all global memory.

In addition, Tigger library functions will disrupt all caller-saved registers.